### PR TITLE
Patch Horizontal Server List

### DIFF
--- a/CollapsibleUI.plugin.js
+++ b/CollapsibleUI.plugin.js
@@ -1907,9 +1907,13 @@ module.exports = class CollapsibleUI {
         if (floating && settings.floatingPanels) {
           elements.serverList.style.setProperty('position', 'absolute', 'important');
           elements.serverList.style.setProperty('z-index', '191', 'important');
-          elements.serverList.style.setProperty('max-height', '100%', 'important');
           elements.serverList.style.setProperty('min-height', '100%', 'important');
           elements.serverList.style.setProperty('overflow-y', 'scroll', 'important');
+          if (runtime.themes.horizontalServerList) {
+            elements.serverList.style.setProperty('max-height', '100vw', 'important');
+          } else {
+            elements.serverList.style.setProperty('max-height', '100%', 'important');
+          }
         }
         else {
           elements.serverList.style.removeProperty('position');


### PR DESCRIPTION
Just a quick and simple patch for the theme HorizontalServerList. Since a while, when hovered, the server list extends only across half of the screen. I don't know if that's because another plugin or something else, but this simple change fixes it. Also, it shouldn't interfere with anything else since I used the theme detection already present. I don't exactly know if that's the right place in the file to put this patch, but its the only place it worked for me.